### PR TITLE
Random search

### DIFF
--- a/API/youtubeAPI.js
+++ b/API/youtubeAPI.js
@@ -71,9 +71,9 @@ async function youtubeAPI(tokens, resolveName, id, args) {
                         allItems = allItems.concat(filteredNewData);
                         nextPageToken = newData.data.nextPageToken;  // Update the nextPageToken
                     }
-
-                    return allItems;
                 }
+
+                return allItems;
 
             case 'videosByHandle':
                 try {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] 
+### Added
+- Randomly gather YouTube video using random search string [#169](https://github.com/ncsa/standalone-smm-smile/issues/169)
+
 ## [0.3.3] - 2024-06-13
 ### Added
 - Gather YouTube video from a given creator handle [#125](https://github.com/ncsa/standalone-smm-smile/issues/125)

--- a/data/schema/youtubeSchema.js
+++ b/data/schema/youtubeSchema.js
@@ -167,6 +167,154 @@ const youtubeQueryType = module.exports = new GraphQLObjectType({
             },
             resolve: (_, args, context) => youtubeAPI(context, resolveName = 'search', id = '', args = args)
         },
+        randomSearch: {
+            type: new GraphQLList(youtubeListType),
+            args: {
+                forContentOwner: {
+                    type: GraphQLBoolean,
+                    description: 'boolean for content owner'
+                },
+                forDeveloper: {
+                    type: GraphQLBoolean,
+                    description: 'boolean for developer'
+                },
+                forMine: {
+                    type: GraphQLBoolean,
+                    description: 'boolean for mine'
+                },
+                part: {
+                    type: GraphQLString,
+                    description: 'The part parameter specifies a comma-separated list of one or more search resource properties that the API response will include. The part names that you can include in the parameter value are id and snippet.',
+                    defaultValue: 'id,snippet'
+                },
+                channelId:{
+                    type: GraphQLString,
+                    description: 'The channelId parameter indicates that the API response should only contain resources created by the channel'
+                },
+                channelType:{
+                    type: GraphQLString,
+                    description: 'any, show',
+                    defaultValue: 'any'
+                },
+                eventType: {
+                    type: GraphQLString,
+                    description: 'completed, live, upcoming',
+                },
+                order: {
+                    type: GraphQLString,
+                    description: 'date, rating, relevance, title, videoCount, viewCount',
+                    defaultValue: 'relevance'
+                },
+                location: {
+                    type: GraphQLString,
+                    description: 'e.g.(37.42307,-122.08427)'
+                },
+                locationRadius: {
+                    type: GraphQLString,
+                    description: `Valid measurement units are m, km, ft, 
+									and mi. For example, valid parameter values include 
+									1500m, 5km, 10000ft, and 0.75mi. The API does not support 
+									locationRadius parameter values larger than 1000 kilometers.`
+                },
+                maxResults: {
+                    type: GraphQLInt,
+                    defaultValue: 50,
+                    description: 'Acceptable values are 0 to 50, inclusive. The default value is 5.'
+                },
+                maxTotalResults: {
+                    type: GraphQLInt,
+                    defaultValue: 50,
+                    description: 'The maximum number of total results to return' // a made up page to control pagination
+                },
+                onBehalfOfContentOwner: {
+                    type: GraphQLString,
+                    description:"This parameter can only be used in a properly authorized request. Note: This parameter is intended exclusively for YouTube content partners."
+                },
+                pageToken:{
+                    type: GraphQLString,
+                    description: 'The pageToken parameter identifies a specific page in the result set that should be returned.'
+                },
+                publishedAfter: {
+                    type: GraphQLString,
+                    description: 'e.g. 1970-01-01T00:00:00Z'
+                },
+                publishedBefore: {
+                    type: GraphQLString,
+                    description: 'e.g. 1970-01-01T00:00:00Z'
+                },
+                regionCode:{
+                    type: GraphQLString,
+                    description: 'ISO 3166-1 alpha-2'
+                },
+                relevanceLanguage: {
+                    type: GraphQLString,
+                    description: 'ISO 639-1'
+                },
+                safeSearch: {
+                    type: GraphQLString,
+                    description: 'moderate, none, strict'
+                },
+                topicId: {
+                    type: GraphQLString,
+                    description: 'e.g. /m/04rlf'
+                },
+                type: {
+                    type: GraphQLString,
+                    defaultValue: 'video',
+                    description: 'channel,playlist,video'
+                },
+                videoCaption: {
+                    type: GraphQLString,
+                    description: 'any, closedCaption, none',
+                    defaultValue: 'any'
+                },
+                videoCategoryId: {
+                    type: GraphQLString,
+                    description: 'e.g. 10'
+                },
+                videoDefinition: {
+                    type: GraphQLString,
+                    description: 'any, high, standard',
+                    defaultValue: 'any'
+                },
+                videoDimension: {
+                    type: GraphQLString,
+                    description: '2d, 3d, any',
+                    defaultValue: 'any'
+                },
+                videoDuration: {
+                    type: GraphQLString,
+                    description: 'any, long, medium, short',
+                    defaultValue: 'any'
+                },
+                videoEmbeddable: {
+                    type: GraphQLString,
+                    description: 'any, true',
+                    defaultValue: 'any'
+                },
+                videoLicense:{
+                    type: GraphQLString,
+                    description: 'any, creativeCommon, youtube',
+                    defaultValue: 'any'
+                },
+                videoSyndicated: {
+                    type: GraphQLString,
+                    description: 'any, true',
+                    defaultValue: 'any'
+                },
+                videoSyndicationType:{
+                    type: GraphQLString,
+                    description: 'any, broadcast, none',
+                    defaultValue: 'any'
+                },
+                videoType: {
+                    type: GraphQLString,
+                    description: 'any, episode, movie',
+                    defaultValue: 'any'
+                }
+            },
+            resolve: (_, args, context) => youtubeAPI(context, resolveName = 'randomSearch', id = '', args = args)
+        },
         videos: {
             type: new GraphQLList(youtubeVideoType),
             args: {


### PR DESCRIPTION
need to be tested.

Pick 4 digits random string based on the paper suggestion.

> youTube video id which does not contain the literal “-” in the prefix, YouTube will return a list of videos whose id’s begin with this prefix followed by “-”, if they exist. The search may also return some videos whose id’s do not contain the prefix, but the title, description or other fields happen to contain the entire search string (including “watch?v=”).When the prefix is short (e.g., 1 or 371 2), it is more likely that the returned search results may contain such “noisy” video ids; with longer prefix length, the probability that this happens becomes zero or extremely small
> 
> On the other hand, using a prefix that is too long may result in a no-hit, i.e., no video id’s being returned. Hence when performing random prefix sampling, the prefix length needs to be carefully selected to balance this trade-off (see Section 4 for details).
> 
> We find that querying prefixes with a prefix length of four (with all returned ids having a “-” in the fifth place)