### PR TITLE
Release/0.3.5

### DIFF
--- a/API/youtubeAPI.js
+++ b/API/youtubeAPI.js
@@ -2,19 +2,30 @@ var google = require('@googleapis/youtube');
 var OAuth2 = google.auth.OAuth2;
 
 async function youtubeAPI(tokens, resolveName, id, args) {
-    var oauth2Client = new OAuth2(
-        GOOGLE_CLIENT_ID,
-        GOOGLE_CLIENT_SECRET
-    );
 
-    oauth2Client.setCredentials({
-        access_token: tokens.googleaccesstoken,
-    });
+    if (tokens.googleaccesstoken) {
+        const oauth2Client = new OAuth2(
+            GOOGLE_CLIENT_ID,
+            GOOGLE_CLIENT_SECRET
+        );
 
-    var youtube = google.youtube({
-        version: 'v3',
-        auth:oauth2Client
-    });
+        oauth2Client.setCredentials({
+            access_token: tokens.googleaccesstoken,
+        });
+
+        youtube = google.youtube({
+            version: 'v3',
+            auth: oauth2Client
+        });
+    }
+    else if (tokens.googleapikey) {
+        youtube = google.youtube({
+            version: 'v3',
+            auth: tokens.googleapikey
+        });
+    } else {
+        throw new Error('No authentication method provided');
+    }
 
     try {
         const pages = args['pages'] - 1;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Google API token as an alternative way to authorize [#179](https://github.com/ncsa/standalone-smm-smile/issues/179)
+- Google API key as an alternative way to authorize [#179](https://github.com/ncsa/standalone-smm-smile/issues/179)
 
 ## [0.3.4] - 2024-06-27 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Google API token as an alternative way to authorize [#179](https://github.com/ncsa/standalone-smm-smile/issues/179)
+
 ## [0.3.4] - 2024-06-27 
 ### Added
 - Randomly gather YouTube video using random search string [#169](https://github.com/ncsa/standalone-smm-smile/issues/169)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.5] - 2024-07-17
 ### Added
 - Google API key as an alternative way to authorize [#179](https://github.com/ncsa/standalone-smm-smile/issues/179)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smile_graphql",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "smile_graphql",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "dependencies": {
         "@googleapis/youtube": "^15.0.0",
         "append-query": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smile_graphql",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "scripts": {
     "start": "forever ./bin/www",


### PR DESCRIPTION
## [0.3.5] - 2024-07-17
### Added
- Google API key as an alternative way to authorize [#179](https://github.com/ncsa/standalone-smm-smile/issues/179)
